### PR TITLE
Update featureFileReader.js

### DIFF
--- a/js/feature/featureFileReader.js
+++ b/js/feature/featureFileReader.js
@@ -114,6 +114,7 @@ var igv = (function (igv) {
 
 
             function parseData(data) {
+                parser = self.parser;
                 self.header = parser.parseHeader(data);
                 if (self.header instanceof String && self.header.startsWith("##gff-version 3")) {
                     self.format = 'gff3';


### PR DESCRIPTION
Added a line to self reference the parser. This seems to solve the issue of the wrong parser being used to read in wig/bedGraph data.
